### PR TITLE
Add Svelecte

### DIFF
--- a/rootfs/package-lock.json
+++ b/rootfs/package-lock.json
@@ -12,9 +12,9 @@
 				"daisyui": "^2.47.0",
 				"home-assistant-js-websocket": "^8.0.1",
 				"iconify-icon": "^1.0.2",
+				"svelecte": "^4.0.0-alpha.7",
 				"svelte-gestures": "^1.4.1",
 				"svelte-grid-extended": "^0.2.0",
-				"svelte-select": "^5.3.1",
 				"svelte-sortable": "^0.1.0"
 			},
 			"devDependencies": {
@@ -387,19 +387,6 @@
 			],
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@floating-ui/core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
-			"integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
-		},
-		"node_modules/@floating-ui/dom": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
-			"integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
-			"dependencies": {
-				"@floating-ui/core": "^1.2.1"
 			}
 		},
 		"node_modules/@iconify/types": {
@@ -2187,6 +2174,14 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/svelecte": {
+			"version": "4.0.0-alpha.7",
+			"resolved": "https://registry.npmjs.org/svelecte/-/svelecte-4.0.0-alpha.7.tgz",
+			"integrity": "sha512-4gG8XQONjBLHnE1hssjp1Fmaf9mKJIDajXebRJkFSqExcjGGv5RLZsFaUywT4LtOT/nUpbtcZ+2scu1uyauHJg==",
+			"dependencies": {
+				"svelte-tiny-virtual-list": "^2.0.0"
+			}
+		},
 		"node_modules/svelte": {
 			"version": "3.55.1",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
@@ -2215,15 +2210,6 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.24.0"
-			}
-		},
-		"node_modules/svelte-floating-ui": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz",
-			"integrity": "sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==",
-			"dependencies": {
-				"@floating-ui/core": "^1.1.0",
-				"@floating-ui/dom": "^1.1.0"
 			}
 		},
 		"node_modules/svelte-gestures": {
@@ -2323,15 +2309,6 @@
 				"sourcemap-codec": "^1.4.8"
 			}
 		},
-		"node_modules/svelte-select": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/svelte-select/-/svelte-select-5.3.1.tgz",
-			"integrity": "sha512-TKlH22FEOr/KYNX4dzBJntNzeI0v0eZYU3VEo2uz/gar6xZdhQ3KT81hvD595GfSB7wiFdYc9SO42wrcgm9W4Q==",
-			"dependencies": {
-				"@floating-ui/dom": "^1.2.1",
-				"svelte-floating-ui": "1.2.8"
-			}
-		},
 		"node_modules/svelte-sortable": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/svelte-sortable/-/svelte-sortable-0.1.0.tgz",
@@ -2342,6 +2319,11 @@
 			"peerDependencies": {
 				"svelte": "^3.0.0"
 			}
+		},
+		"node_modules/svelte-tiny-virtual-list": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/svelte-tiny-virtual-list/-/svelte-tiny-virtual-list-2.0.5.tgz",
+			"integrity": "sha512-xg9ckb8UeeIme4/5qlwCrl2QNmUZ8SCQYZn3Ji83cUsoASqRNy3KWjpmNmzYvPDqCHSZjruBBsoB7t5hwuzw5g=="
 		},
 		"node_modules/tailwindcss": {
 			"version": "3.2.4",
@@ -2762,19 +2744,6 @@
 			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
 			"dev": true,
 			"optional": true
-		},
-		"@floating-ui/core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
-			"integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
-		},
-		"@floating-ui/dom": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
-			"integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
-			"requires": {
-				"@floating-ui/core": "^1.2.1"
-			}
 		},
 		"@iconify/types": {
 			"version": "2.0.0",
@@ -4008,6 +3977,14 @@
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
 		},
+		"svelecte": {
+			"version": "4.0.0-alpha.7",
+			"resolved": "https://registry.npmjs.org/svelecte/-/svelecte-4.0.0-alpha.7.tgz",
+			"integrity": "sha512-4gG8XQONjBLHnE1hssjp1Fmaf9mKJIDajXebRJkFSqExcjGGv5RLZsFaUywT4LtOT/nUpbtcZ+2scu1uyauHJg==",
+			"requires": {
+				"svelte-tiny-virtual-list": "^2.0.0"
+			}
+		},
 		"svelte": {
 			"version": "3.55.1",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
@@ -4027,15 +4004,6 @@
 				"sade": "^1.7.4",
 				"svelte-preprocess": "^4.0.0",
 				"typescript": "*"
-			}
-		},
-		"svelte-floating-ui": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz",
-			"integrity": "sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==",
-			"requires": {
-				"@floating-ui/core": "^1.1.0",
-				"@floating-ui/dom": "^1.1.0"
 			}
 		},
 		"svelte-gestures": {
@@ -4080,15 +4048,6 @@
 				}
 			}
 		},
-		"svelte-select": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/svelte-select/-/svelte-select-5.3.1.tgz",
-			"integrity": "sha512-TKlH22FEOr/KYNX4dzBJntNzeI0v0eZYU3VEo2uz/gar6xZdhQ3KT81hvD595GfSB7wiFdYc9SO42wrcgm9W4Q==",
-			"requires": {
-				"@floating-ui/dom": "^1.2.1",
-				"svelte-floating-ui": "1.2.8"
-			}
-		},
 		"svelte-sortable": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/svelte-sortable/-/svelte-sortable-0.1.0.tgz",
@@ -4096,6 +4055,11 @@
 			"requires": {
 				"sortablejs": "^1.10.1"
 			}
+		},
+		"svelte-tiny-virtual-list": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/svelte-tiny-virtual-list/-/svelte-tiny-virtual-list-2.0.5.tgz",
+			"integrity": "sha512-xg9ckb8UeeIme4/5qlwCrl2QNmUZ8SCQYZn3Ji83cUsoASqRNy3KWjpmNmzYvPDqCHSZjruBBsoB7t5hwuzw5g=="
 		},
 		"tailwindcss": {
 			"version": "3.2.4",

--- a/rootfs/package-lock.json
+++ b/rootfs/package-lock.json
@@ -14,6 +14,7 @@
 				"iconify-icon": "^1.0.2",
 				"svelte-gestures": "^1.4.1",
 				"svelte-grid-extended": "^0.2.0",
+				"svelte-select": "^5.3.1",
 				"svelte-sortable": "^0.1.0"
 			},
 			"devDependencies": {
@@ -386,6 +387,19 @@
 			],
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+			"integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+			"dependencies": {
+				"@floating-ui/core": "^1.2.1"
 			}
 		},
 		"node_modules/@iconify/types": {
@@ -2203,6 +2217,15 @@
 				"svelte": "^3.24.0"
 			}
 		},
+		"node_modules/svelte-floating-ui": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz",
+			"integrity": "sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==",
+			"dependencies": {
+				"@floating-ui/core": "^1.1.0",
+				"@floating-ui/dom": "^1.1.0"
+			}
+		},
 		"node_modules/svelte-gestures": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/svelte-gestures/-/svelte-gestures-1.4.1.tgz",
@@ -2298,6 +2321,15 @@
 			"dev": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/svelte-select": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/svelte-select/-/svelte-select-5.3.1.tgz",
+			"integrity": "sha512-TKlH22FEOr/KYNX4dzBJntNzeI0v0eZYU3VEo2uz/gar6xZdhQ3KT81hvD595GfSB7wiFdYc9SO42wrcgm9W4Q==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.2.1",
+				"svelte-floating-ui": "1.2.8"
 			}
 		},
 		"node_modules/svelte-sortable": {
@@ -2730,6 +2762,19 @@
 			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
 			"dev": true,
 			"optional": true
+		},
+		"@floating-ui/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+		},
+		"@floating-ui/dom": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+			"integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+			"requires": {
+				"@floating-ui/core": "^1.2.1"
+			}
 		},
 		"@iconify/types": {
 			"version": "2.0.0",
@@ -3984,6 +4029,15 @@
 				"typescript": "*"
 			}
 		},
+		"svelte-floating-ui": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz",
+			"integrity": "sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==",
+			"requires": {
+				"@floating-ui/core": "^1.1.0",
+				"@floating-ui/dom": "^1.1.0"
+			}
+		},
 		"svelte-gestures": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/svelte-gestures/-/svelte-gestures-1.4.1.tgz",
@@ -4024,6 +4078,15 @@
 						"sourcemap-codec": "^1.4.8"
 					}
 				}
+			}
+		},
+		"svelte-select": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/svelte-select/-/svelte-select-5.3.1.tgz",
+			"integrity": "sha512-TKlH22FEOr/KYNX4dzBJntNzeI0v0eZYU3VEo2uz/gar6xZdhQ3KT81hvD595GfSB7wiFdYc9SO42wrcgm9W4Q==",
+			"requires": {
+				"@floating-ui/dom": "^1.2.1",
+				"svelte-floating-ui": "1.2.8"
 			}
 		},
 		"svelte-sortable": {

--- a/rootfs/package.json
+++ b/rootfs/package.json
@@ -36,9 +36,9 @@
 		"daisyui": "^2.47.0",
 		"home-assistant-js-websocket": "^8.0.1",
 		"iconify-icon": "^1.0.2",
+		"svelecte": "^4.0.0-alpha.7",
 		"svelte-gestures": "^1.4.1",
 		"svelte-grid-extended": "^0.2.0",
-		"svelte-select": "^5.3.1",
 		"svelte-sortable": "^0.1.0"
 	}
 }

--- a/rootfs/package.json
+++ b/rootfs/package.json
@@ -38,6 +38,7 @@
 		"iconify-icon": "^1.0.2",
 		"svelte-gestures": "^1.4.1",
 		"svelte-grid-extended": "^0.2.0",
+		"svelte-select": "^5.3.1",
 		"svelte-sortable": "^0.1.0"
 	}
 }

--- a/rootfs/src/lib/apistore.ts
+++ b/rootfs/src/lib/apistore.ts
@@ -7,8 +7,10 @@ import {
 	createLongLivedTokenAuth,
 	subscribeEntities,
 	callService,
+	subscribeServices,
 	Connection,
 	type HassEntities,
+	type HassServices,
 	getAuth,
 	type SaveTokensFunc,
 	ERR_INVALID_AUTH
@@ -72,6 +74,24 @@ export const stateStore = readable<null | HassEntities>(null, function start(set
 	}
 	return function stop() {}
 });
+
+export const serviceStore = readable<string[]>([], function start(set) {
+	let unsubscribe: Function;
+	if (browser && conn) {
+		unsubscribe = subscribeServices(conn, (services) => {
+			let serviceList = []
+			for (const [k, v] of Object.entries(services)) {
+				for (const [k1, v1] of Object.entries(v)) {
+					serviceList.push(`${k}.${k1}`)
+				}
+			}
+			set(serviceList.sort());
+		})
+	}
+	return function stop() {
+		unsubscribe();
+	}
+})
 
 
 export const action = (serviceType: string, target: string) => {

--- a/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
+++ b/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import type { PageData } from './$types';
+    import Select from 'svelte-select';
     export let data: PageData;
+    data.entities = ['', ...data.entities];
     let newDisableRows = 0;
 </script>
 
@@ -26,14 +28,7 @@
                 {/each}
             </select><br>
             <label for="music-entity">Background Music Entity</label>
-            <select name="backgroundMusicEntity" id="music-entity">
-                <option value="" selected={data.configuration?.backgroundMusicEntity === null}>None (Disable background audio player)</option>
-                {#each data.entities as entity}
-                    {#if entity.startsWith('input_boolean')}
-                        <option value={entity} selected={data.configuration?.backgroundMusicEntity === entity}>{entity}</option>
-                    {/if}
-                {/each}
-            </select><br>
+            <Select class="select select-bordered w-full bg-secondary-focus" name="backgroundMusicEntity" items={data.entities} value={data.configuration?.backgroundMusicEntity === null ? '' : data.configuration?.backgroundMusicEntity} />
             <label for="music-file">Background Music File</label>
             <input type="text" id="music-file" name="backgroundMusicFile" value={data.configuration?.backgroundMusicFile}><br>
             {#if !(data.baseSettings.googleClientId)}

--- a/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
+++ b/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
@@ -53,24 +53,15 @@
             {#each data.configuration?.disableSlideShow as d, idx}
                 <input type="checkbox" id={"delete_"+d.uid} name={"delete_"+d.uid}>
                 <label for={"entity_"+d.uid}>Entity</label>
-                <select name={"entity_"+d.uid} id={"entity_"+d.uid}>
-                    {#each data.entities as entity}
-                        <option value={entity} selected={d.entity === entity}>{entity}</option>
-                    {/each}
-                </select><br>
+                <Select name={"entity_"+d.uid} options={entities.slice(1)} valueField="value" labelField="label" value={d.entity} />
                 <label for={"state"+d.uid}>State to Match</label>
-                <input type="text" id={"state"+d.uid} name={"state"+d.uid} value={d.state}><br>
+                <input type="text" id={"state"+d.uid} name={"state"+d.uid} value={d.state}><br><br>
             {/each}
             {/if}
             <button class="btn btn-primary" on:click|preventDefault={() => newDisableRows++}>Add State</button>
             {#each Array(newDisableRows) as _, idx}
                 <label for={"new_entity_"+ idx}>Entity</label>
-                <select name={"new_entity_"+idx} id={"new_entity_"+idx}>
-                    <option value=""></option>
-                    {#each data.entities as entity}
-                        <option value={entity}>{entity}</option>
-                    {/each}
-                </select><br>
+                <Select name={"new_entity_"+ idx} options={entities.slice(1)} valueField="value" labelField="label" />
                 <label for={"new_state_"+idx}>State to Match</label>
                 <input type="text" id={"new_state_"+idx} name={"new_state_"+idx}><br>
             {/each}

--- a/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
+++ b/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import type { PageData } from './$types';
-    import Select from 'svelte-select';
+    import Select from 'svelecte/src/Svelecte.svelte';
     export let data: PageData;
-    let bgAudioEntities = [{value: '', label: 'None (disable background audio player'}, ...data.entities.map(e => ({value: e, label: e}))];
+    let entities = [{value: "", label: 'None (disable background audio player)'}, ...data.entities.map(e => ({value: e, label: e}))];
     let newDisableRows = 0;
 </script>
 
@@ -28,7 +28,7 @@
                 {/each}
             </select><br>
             <label for="music-entity">Background Music Entity</label>
-            <Select name="backgroundMusicEntity" items={bgAudioEntities} value={(data.configuration?.backgroundMusicEntity ?? '') === '' ? 'None (disable background audio player' : data.configuration?.backgroundMusicEntity} />
+            <Select name="backgroundMusicEntity" options={entities} valueField="value" labelField="label" value={data.configuration?.backgroundMusicEntity ?? ""} />
             <label for="music-file">Background Music File</label>
             <input type="text" id="music-file" name="backgroundMusicFile" value={data.configuration?.backgroundMusicFile}><br>
             {#if !(data.baseSettings.googleClientId)}

--- a/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
+++ b/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
@@ -2,7 +2,7 @@
     import type { PageData } from './$types';
     import Select from 'svelte-select';
     export let data: PageData;
-    data.entities = ['', ...data.entities];
+    let bgAudioEntities = [{value: '', label: 'None (disable background audio player'}, ...data.entities.map(e => ({value: e, label: e}))];
     let newDisableRows = 0;
 </script>
 
@@ -28,7 +28,7 @@
                 {/each}
             </select><br>
             <label for="music-entity">Background Music Entity</label>
-            <Select class="select select-bordered w-full bg-secondary-focus" name="backgroundMusicEntity" items={data.entities} value={data.configuration?.backgroundMusicEntity === null ? '' : data.configuration?.backgroundMusicEntity} />
+            <Select name="backgroundMusicEntity" items={bgAudioEntities} value={(data.configuration?.backgroundMusicEntity ?? '') === '' ? 'None (disable background audio player' : data.configuration?.backgroundMusicEntity} />
             <label for="music-file">Background Music File</label>
             <input type="text" id="music-file" name="backgroundMusicFile" value={data.configuration?.backgroundMusicFile}><br>
             {#if !(data.baseSettings.googleClientId)}

--- a/rootfs/src/routes/(app)/[name]/tiles/LightTile/LightTileConfig.svelte
+++ b/rootfs/src/routes/(app)/[name]/tiles/LightTile/LightTileConfig.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 	import type { LightTileConfig } from "$lib/types";
+    import { stateStore } from "$lib/apistore";
+    import Select from 'svelecte/src/Svelecte.svelte';
+
+    const entities = Object.keys($stateStore ?? {"Could not load entities": ''}).sort();
+    console.log(entities);
 
     export let data: LightTileConfig
 </script>
@@ -18,4 +23,4 @@
   <label class="label" for="entity">
       <span class="label-text">Entity ID</span>
   </label>
-  <input required name="entity" type="text" id="entity" class="input input-bordered w-full" value={data?.entity ?? ''} />
+  <Select name="entity" options={entities} labelAsValue={true} value={data?.entity ?? ''} />

--- a/rootfs/src/routes/(app)/[name]/tiles/LightTile/LightTileConfig.svelte
+++ b/rootfs/src/routes/(app)/[name]/tiles/LightTile/LightTileConfig.svelte
@@ -4,8 +4,6 @@
     import Select from 'svelecte/src/Svelecte.svelte';
 
     const entities = Object.keys($stateStore ?? {"Could not load entities": ''}).sort();
-    console.log(entities);
-
     export let data: LightTileConfig
 </script>
 

--- a/rootfs/src/routes/(app)/[name]/tiles/ServiceTile/ServiceTileConfig.svelte
+++ b/rootfs/src/routes/(app)/[name]/tiles/ServiceTile/ServiceTileConfig.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import type { ServiceTileConfig } from "$lib/types";
+    import { stateStore, serviceStore } from "$lib/apistore";
+    import Select from 'svelecte/src/Svelecte.svelte';
 
+    const entities = Object.keys($stateStore ?? {"Could not load entities": ''}).sort();
     export let data: ServiceTileConfig;
 </script>
 
@@ -18,11 +21,13 @@
   <label class="label" for="serviceType">
       <span class="label-text">Service Type</span>
   </label>
-  <input required name="serviceType" type="text" id="serviceType" class="input input-bordered w-full" value={data?.serviceType ?? ''} />
+  {#if $serviceStore.length > 0}
+  <Select name="serviceType" options={$serviceStore} labelAsValue={true} value={data?.serviceType ?? ''} />
+  {/if}
   <label class="label" for="target">
       <span class="label-text">Target</span>
   </label>
-  <input required name="target" type="text" id="target" class="input input-bordered w-full" value={data?.target ?? ''} />
+  <Select name="target" options={entities} labelAsValue={true} value={data?.target ?? ''} />
   <label class="label" for="text">
       <span class="label-text">Tile Text</span>
   </label>

--- a/rootfs/src/routes/+layout.svelte
+++ b/rootfs/src/routes/+layout.svelte
@@ -1,0 +1,28 @@
+<slot />
+
+<style lang="postcss">
+    :global(.svelecte) {
+        --sv-bg: #555355 !important;
+        --sv-item-color: #EBECF0 !important;
+        --sv-highlight-bg: #378B82 !important;
+        --sv-item-active-bg: transparent !important;
+        --sv-border-color: rgba(235, 236, 240, 0.2) !important;
+    }
+    
+    :global(.sv-control) {
+        @apply select select-bordered w-full bg-secondary-focus !rounded-lg;
+    }
+
+    :global(.is-active) {
+        outline-offset: 2px;
+        outline: 2px solid rgba(235, 236, 240, 0.2) !important;
+    }
+
+    :global(.sv-content) {
+        @apply !p-0;
+    }
+
+    :global(.indicator) {
+        visibility: hidden;
+    }
+</style>


### PR DESCRIPTION
Adds Svelecte to the configuration workflows for setting up dashboard audio and slideshows, and for the light and service tiles. This allows for search as you type when looking for entities.

Future tiles should always use svelecte for entity selection.