### PR TITLE
Link to install instructions when error fetching entities occurs

### DIFF
--- a/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
+++ b/rootfs/src/routes/(admin)/config/[[uid]]/+page.svelte
@@ -6,7 +6,7 @@
     let newDisableRows = 0;
 </script>
 
-    {#if "error" in data}{data.error}
+    {#if "error" in data}{@html data.error}
     {:else if data.entities?.length === 0}Loading...
     {:else}
         <form method="POST">

--- a/rootfs/src/routes/(admin)/config/[[uid]]/+page.ts
+++ b/rootfs/src/routes/(admin)/config/[[uid]]/+page.ts
@@ -29,7 +29,13 @@ export const load = (async ({ data, fetch }) => {
             )
         }
         catch (err) {
-            return { ...data, entities: [], error: "Error fetching entities from Home Assistant" }
+            return { ...data, entities: [], error: 
+                `Error fetching entities from Home Assistant<br>
+                Please ensure that you've configured Photodash as an allowed
+                CORS origin in Home Assistant
+                (follow instructions at <a href="https://photodash.apop.tech/docs/installation" class="link" target="_blank" rel="noreferrer">
+                https://photodash.apop.tech/docs/installation</a>)` 
+            }
         }
         const json: Array<Entity> = await statesRes.json();
         const entities = json.map(e => e.entity_id).sort();


### PR DESCRIPTION
If someone tries to install the addon and gets started without reading the documentation, this is likely the first spot where they are likely to get stuck.

If there's an error fetching entities when creating a new configuration, it's likely because CORS configuration wasn't done in Home Assistant. This PR will add a link directly to the relevant docs when this error occurs.